### PR TITLE
Lsb4 stego

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:latest
 
-RUN apk --no-cache add build-base openssl-dev make cmake gdb valgrind
+RUN apk --no-cache add build-base openssl-dev openssl make cmake gdb valgrind
 
 RUN addgroup -g 1001 stego \
     && adduser -D -u 1001 -G stego stego \

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+include Makefile.inc
+
 ifneq ($(DEBUG), 0)
 CFLAGS += -g -DDEVELOPMENT
 else

--- a/run.sh
+++ b/run.sh
@@ -1,13 +1,14 @@
 #!/bin/bash
 img=$1
 msg=$2
+stg=$3
 
 make clean all DEBUG=1
 
 extension=${msg##*.}
 
-./bin/stego -embed -p $img -in $msg -out out.bmp
-./bin/stego -extract -p out.bmp -out extracted
+./bin/stego -embed -p $img -in $msg -out out.bmp -stego $stg
+./bin/stego -extract -p out.bmp -out extracted -stego $stg
 
 echo
 diff $msg extracted.$extension

--- a/src/include/readers.h
+++ b/src/include/readers.h
@@ -34,3 +34,11 @@ Data get_message(const char *input);
  * @return char* The retrieved message
  */
 Stego *retrieve_lsb1(const char *fileName, size_t offset, char **extension);
+
+/**
+ * @brief Retrieve a steganographed message using LSB4 method
+ *
+ * @param fileName The name of the file to retrieve the message from
+ * @return char* The retrieved message
+ */
+Stego *retrieve_lsb4(const char *fileName, size_t offset, char **extension);

--- a/src/include/stego.h
+++ b/src/include/stego.h
@@ -1,4 +1,5 @@
 #include <stdint.h>
+#include <stdio.h>
 
 typedef struct {
     uint32_t size;

--- a/src/include/stego.h
+++ b/src/include/stego.h
@@ -11,3 +11,11 @@ typedef struct {
     uint8_t data[];
 } Stego;
 
+typedef size_t (*Writer)(FILE *output, const uint8_t *input, size_t size);
+typedef Stego *(*Reader)(const char *file_name, size_t offset, char **extension);
+
+typedef struct {
+    char name[5];
+    Writer embed;
+    Reader retrieve;
+} StegoMethod;

--- a/src/include/writers.h
+++ b/src/include/writers.h
@@ -2,8 +2,6 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-typedef size_t (*Writer)(FILE *output, const uint8_t *input, size_t size);
-
 /**
  * @brief Write data into the output file using LSB1 steganography.
  *
@@ -15,3 +13,15 @@ typedef size_t (*Writer)(FILE *output, const uint8_t *input, size_t size);
  * @return size_t The number of bytes successfully embedded, or 0 on failure
  */
 size_t embed_data_lsb1(FILE *output, const uint8_t *input, size_t size);
+
+/**
+ * @brief Write data into the output file using LSB4 steganography.
+ *
+ * @note The function does not reset the file header position
+ *
+ * @param output The output file where data will be embedded (writes at current header position)
+ * @param input The input data to be embedded
+ * @param size The size of the input data
+ * @return size_t The number of bytes successfully embedded, or 0 on failure
+ */
+size_t embed_data_lsb4(FILE *output, const uint8_t *input, size_t size);

--- a/src/readers/bmp.c
+++ b/src/readers/bmp.c
@@ -43,5 +43,12 @@ size_t get_output(FILE **file, const char *output, const char *input)
     close(ifd);
 
     *file = fdopen(ofd, "r+b");
+    if (*file == NULL)
+    {
+        perror("Error converting file descriptor to FILE*");
+        close(ofd);
+        return 0;
+    }
+
     return stats.st_size;
 }

--- a/src/readers/input_file.c
+++ b/src/readers/input_file.c
@@ -4,6 +4,7 @@
 #include <string.h>
 
 #include <stego.h>
+#include <logs.h>
 
 Data get_message(const char *input)
 {

--- a/src/readers/input_file.c
+++ b/src/readers/input_file.c
@@ -67,9 +67,9 @@ Data get_message(const char *input)
         return (Data){};
     }
 
-    printf("Input file size: %u bytes\n", input_data.size);
-    printf("Input file extension: %s\n", input_data.ext);
-    printf("Input file data: %.*s\n", input_data.size, input_data.data);
+    LOG("Input file size: %u bytes\n", input_data.size);
+    LOG("Input file extension: %s\n", input_data.ext);
+    LOG("Input file data: %.*s\n", input_data.size, input_data.data);
 
     return input_data;
 }

--- a/src/readers/lsb1.c
+++ b/src/readers/lsb1.c
@@ -87,7 +87,8 @@ Stego *retrieve_lsb1(const char *file_name, size_t offset, char **extension)
     if (extension != NULL)
     {
         int length = 0;
-        while (true)
+        uint8_t byte = 0;
+        do
         {
             if (length % EXTENSION_BLOCK_LENGTH == 0)
             {
@@ -106,7 +107,6 @@ Stego *retrieve_lsb1(const char *file_name, size_t offset, char **extension)
                 *extension = tmp;
             }
 
-            uint8_t byte = 0;
             for (size_t i = 0; i < 8; i++)
             {
                 char image_byte = fgetc(file);
@@ -127,12 +127,7 @@ Stego *retrieve_lsb1(const char *file_name, size_t offset, char **extension)
 
             LOG("Extension byte: %c\n", byte);
             (*extension)[length++] = byte;
-
-            if (!byte)
-            {
-                break;
-            }
-        }
+        } while (byte != 0);
     }
 
     fclose(file);

--- a/src/readers/lsb1.c
+++ b/src/readers/lsb1.c
@@ -19,7 +19,7 @@ Stego *retrieve_lsb1(FILE *file, size_t offset, char **extension)
         perror("Failed to seek to offset in file");
         return NULL;
     }
-    
+
     const uint32_t message_length = get_length(file);
     if (message_length == 0)
     {
@@ -43,6 +43,10 @@ Stego *retrieve_lsb1(FILE *file, size_t offset, char **extension)
         if (feof(file))
         {
             perror("Not enough bytes to read message");
+            LOG("Reached EOF at byte %zu\n", i);
+
+            free(stego);
+
             return NULL;
         }
 

--- a/src/readers/lsb1.c
+++ b/src/readers/lsb1.c
@@ -19,7 +19,7 @@ Stego *retrieve_lsb1(FILE *file, size_t offset, char **extension)
         perror("Failed to seek to offset in file");
         return NULL;
     }
-
+    
     const uint32_t message_length = get_length(file);
     if (message_length == 0)
     {
@@ -28,11 +28,10 @@ Stego *retrieve_lsb1(FILE *file, size_t offset, char **extension)
 
     LOG("Message length: %u\n", message_length);
 
-    // Allocate memory for the message
-    uint8_t *message = malloc(message_length);
-    if (message == NULL)
+    Stego *stego = malloc(sizeof(Stego) + message_length);
+    if (stego == NULL)
     {
-        perror("Memory allocation for message failed");
+        perror("Memory allocation for Stego failed");
         return NULL;
     }
 
@@ -44,28 +43,14 @@ Stego *retrieve_lsb1(FILE *file, size_t offset, char **extension)
         if (feof(file))
         {
             perror("Not enough bytes to read message");
-            free(message);
             return NULL;
         }
 
-        message[i / 8] <<= 1;
-        message[i / 8] |= (byte & 1);
-    }
-
-    LOG("Message: %.*s\n", message_length, message);
-
-    Stego *stego = malloc(sizeof(Stego) + message_length);
-    if (stego == NULL)
-    {
-        perror("Memory allocation for Stego failed");
-        free(message);
-        return NULL;
+        (stego->data)[i / 8] <<= 1;
+        (stego->data)[i / 8] |= (byte & 1);
     }
 
     stego->size = message_length;
-    memcpy(stego->data, message, message_length);
-
-    free(message);
 
     if (extension != NULL)
     {

--- a/src/readers/lsb4.c
+++ b/src/readers/lsb4.c
@@ -12,15 +12,8 @@
 
 static uint32_t get_length(FILE *file);
 
-Stego *retrieve_lsb4(const char *file_name, size_t offset, char **extension)
+Stego *retrieve_lsb4(FILE *file, size_t offset, char **extension)
 {
-    FILE *file = fopen(file_name, "rb");
-    if (file == NULL)
-    {
-        perror("Error opening file");
-        return NULL;
-    }
-
     if (fseek(file, offset, SEEK_SET) < 0)
     {
         perror("File too small for offset");

--- a/src/readers/lsb4.c
+++ b/src/readers/lsb4.c
@@ -17,14 +17,12 @@ Stego *retrieve_lsb4(FILE *file, size_t offset, char **extension)
     if (fseek(file, offset, SEEK_SET) < 0)
     {
         perror("File too small for offset");
-        fclose(file);
         return NULL;
     }
 
     const uint32_t message_length = get_length(file);
     if (message_length == 0)
     {
-        fclose(file);
         return NULL;
     }
 
@@ -35,7 +33,6 @@ Stego *retrieve_lsb4(FILE *file, size_t offset, char **extension)
     if (message == NULL)
     {
         perror("Memory allocation for message failed");
-        fclose(file);
         return NULL;
     }
 
@@ -50,7 +47,6 @@ Stego *retrieve_lsb4(FILE *file, size_t offset, char **extension)
             LOG("Reached EOF at byte %zu\n", i);
 
             free(message);
-            fclose(file);
 
             return NULL;
         }
@@ -67,7 +63,6 @@ Stego *retrieve_lsb4(FILE *file, size_t offset, char **extension)
         perror("Memory allocation for Stego failed");
 
         free(message);
-        fclose(file);
 
         return NULL;
     }
@@ -91,7 +86,6 @@ Stego *retrieve_lsb4(FILE *file, size_t offset, char **extension)
 
                     free(*extension);
                     free(stego);
-                    fclose(file);
 
                     return NULL;
                 }
@@ -110,7 +104,6 @@ Stego *retrieve_lsb4(FILE *file, size_t offset, char **extension)
                     perror("Error reading file");
                     free(*extension);
                     free(stego);
-                    fclose(file);
                     return NULL;
                 }
 
@@ -128,7 +121,6 @@ Stego *retrieve_lsb4(FILE *file, size_t offset, char **extension)
         }
     }
 
-    fclose(file);
     return stego;
 }
 

--- a/src/readers/lsb4.c
+++ b/src/readers/lsb4.c
@@ -56,8 +56,9 @@ Stego *retrieve_lsb4(FILE *file, size_t offset, char **extension)
 
     if (extension != NULL)
     {
-        int length = 0;
-        while (true)
+                int length = 0;
+        uint8_t byte = 0;
+        do
         {
             if (length % EXTENSION_BLOCK_LENGTH == 0)
             {
@@ -75,7 +76,6 @@ Stego *retrieve_lsb4(FILE *file, size_t offset, char **extension)
                 *extension = tmp;
             }
 
-            uint8_t byte = 0;
             for (size_t i = 0; i < 2; i++)
             {
                 char image_byte = fgetc(file);
@@ -95,12 +95,7 @@ Stego *retrieve_lsb4(FILE *file, size_t offset, char **extension)
 
             LOG("Extension byte: %c\n", byte);
             (*extension)[length++] = byte;
-
-            if (!byte)
-            {
-                break;
-            }
-        }
+        } while (byte != 0);
     }
 
     return stego;

--- a/src/readers/lsb4.c
+++ b/src/readers/lsb4.c
@@ -27,15 +27,14 @@ Stego *retrieve_lsb4(FILE *file, size_t offset, char **extension)
     }
 
     LOG("Message length: %u\n", message_length);
-
-    // Allocate memory for the message
-    uint8_t *message = malloc(message_length);
-    if (message == NULL)
+    
+    Stego *stego = malloc(sizeof(Stego) + message_length);
+    if (stego == NULL)
     {
-        perror("Memory allocation for message failed");
+        perror("Memory allocation for Stego failed");
         return NULL;
     }
-
+    
     // Read the message bits
     for (size_t i = 0; i < message_length * 2; i++)
     {
@@ -46,31 +45,14 @@ Stego *retrieve_lsb4(FILE *file, size_t offset, char **extension)
             perror("Not enough bytes to read message");
             LOG("Reached EOF at byte %zu\n", i);
 
-            free(message);
-
             return NULL;
         }
 
-        message[i / 2] <<= 4;
-        message[i / 2] |= (byte & 0x0F);
-    }
-
-    LOG("Message: %.*s\n", message_length, message);
-
-    Stego *stego = malloc(sizeof(Stego) + message_length);
-    if (stego == NULL)
-    {
-        perror("Memory allocation for Stego failed");
-
-        free(message);
-
-        return NULL;
+        (stego->data)[i / 2] <<= 4;
+        (stego->data)[i / 2] |= (byte & 0x0F);
     }
 
     stego->size = message_length;
-    memcpy(stego->data, message, message_length);
-
-    free(message);
 
     if (extension != NULL)
     {

--- a/src/readers/lsb4.c
+++ b/src/readers/lsb4.c
@@ -27,14 +27,14 @@ Stego *retrieve_lsb4(FILE *file, size_t offset, char **extension)
     }
 
     LOG("Message length: %u\n", message_length);
-    
+
     Stego *stego = malloc(sizeof(Stego) + message_length);
     if (stego == NULL)
     {
         perror("Memory allocation for Stego failed");
         return NULL;
     }
-    
+
     // Read the message bits
     for (size_t i = 0; i < message_length * 2; i++)
     {
@@ -44,6 +44,8 @@ Stego *retrieve_lsb4(FILE *file, size_t offset, char **extension)
         {
             perror("Not enough bytes to read message");
             LOG("Reached EOF at byte %zu\n", i);
+
+            free(stego);
 
             return NULL;
         }
@@ -56,7 +58,7 @@ Stego *retrieve_lsb4(FILE *file, size_t offset, char **extension)
 
     if (extension != NULL)
     {
-                int length = 0;
+        int length = 0;
         uint8_t byte = 0;
         do
         {

--- a/src/stego.c
+++ b/src/stego.c
@@ -249,7 +249,7 @@ static const StegoMethod *get_stego_method(const char *name)
     size_t methods_count = sizeof(stego_methods) / sizeof(StegoMethod);
     for (size_t i = 0; i < methods_count; i++)
     {
-        if (strcmp(stego_methods[i].name, name) == 0)
+        if (strcasecmp(stego_methods[i].name, name) == 0)
         {
             return &stego_methods[i];
         }

--- a/src/stego.c
+++ b/src/stego.c
@@ -254,5 +254,6 @@ static const StegoMethod *get_stego_method(const char *name)
             return &stego_methods[i];
         }
     }
+
     return NULL;
 }

--- a/src/stego.c
+++ b/src/stego.c
@@ -118,7 +118,7 @@ int main(int argc, char *argv[])
         size_bytes[2] = (input_data.size >> 8) & 0xFF;
         size_bytes[3] = input_data.size & 0xFF;
 
-        if (stego_methods->embed(porter, size_bytes, 4) == 0)
+        if (stego_type->embed(porter, size_bytes, 4) == 0)
         {
             fprintf(stderr, "Failed to embed size data.\n");
             free(input_data.data);
@@ -126,7 +126,7 @@ int main(int argc, char *argv[])
             fclose(porter);
             return EXIT_FAILURE;
         }
-        if (stego_methods->embed(porter, (uint8_t *)input_data.data, input_data.size) == 0)
+        if (stego_type->embed(porter, (uint8_t *)input_data.data, input_data.size) == 0)
         {
             fprintf(stderr, "Failed to embed input data.\n");
             free(input_data.data);
@@ -134,7 +134,7 @@ int main(int argc, char *argv[])
             fclose(porter);
             return EXIT_FAILURE;
         }
-        if (stego_methods->embed(porter, (uint8_t *)input_data.ext, strlen(input_data.ext) + 1) == 0)
+        if (stego_type->embed(porter, (uint8_t *)input_data.ext, strlen(input_data.ext) + 1) == 0)
         {
             fprintf(stderr, "Failed to embed file extension data.\n");
             free(input_data.data);
@@ -175,7 +175,7 @@ int main(int argc, char *argv[])
         LOG("BMP Header size: %u\n", header_size);
 
         char *extension = NULL;
-        Stego *stego = stego_methods->retrieve(porter, header_size, &extension);
+        Stego *stego = stego_type->retrieve(porter, header_size, &extension);
         fclose(porter);
 
         if (stego == NULL)

--- a/src/stego.c
+++ b/src/stego.c
@@ -62,11 +62,11 @@ int main(int argc, char *argv[])
 
     if (!extract_mode)
     {
-        printf("Embedding mode:\n");
-        printf("Input file: %s\n", input_file_name);
-        printf("Porter file: %s\n", porter_file_name);
-        printf("Output file: %s\n", output_file_name);
-        printf("Stego type: %s\n", stego_type->name);
+        LOG("Embedding mode:\n");
+        LOG("Input file: %s\n", input_file_name);
+        LOG("Porter file: %s\n", porter_file_name);
+        LOG("Output file: %s\n", output_file_name);
+        LOG("Stego type: %s\n", stego_type->name);
 
         FILE *porter;
         long porter_size = get_output(&porter, output_file_name, porter_file_name);
@@ -152,9 +152,9 @@ int main(int argc, char *argv[])
     }
     else
     {
-        printf("Extracting mode:\n");
-        printf("Porter file: %s\n", porter_file_name);
-        printf("Output file: %s\n", output_file_name);
+        LOG("Extracting mode:\n");
+        LOG("Porter file: %s\n", porter_file_name);
+        LOG("Output file: %s\n", output_file_name);
 
         FILE *porter = fopen(porter_file_name, "rb");
         if (porter == NULL)

--- a/src/writers/lsb1.c
+++ b/src/writers/lsb1.c
@@ -32,11 +32,11 @@ size_t embed_data_lsb1(FILE *output, const uint8_t *input, size_t size)
     {
         uint8_t byte = input[curr_byte / 8];
 
-        printf("Embedding byte: %02X\n", byte);
+        LOG("Embedding byte: %02X\n", byte);
         for (int i = 7; i >= 0; i--)
         {
             uint8_t bit = (byte >> i) & 1;
-            printf("Embedding bit: %d\n", bit);
+            LOG("Embedding bit: %d\n", bit);
 
             data[curr_byte] = (data[curr_byte] & 0xFE) | bit;
             curr_byte++;

--- a/src/writers/lsb1.c
+++ b/src/writers/lsb1.c
@@ -1,4 +1,5 @@
 #include <writers.h>
+#include <logs.h>
 
 size_t embed_data_lsb1(FILE *output, const uint8_t *input, size_t size)
 {

--- a/src/writers/lsb4.c
+++ b/src/writers/lsb4.c
@@ -1,4 +1,5 @@
 #include <writers.h>
+#include <logs.h>
 
 size_t embed_data_lsb4(FILE *output, const uint8_t *input, size_t size)
 {

--- a/src/writers/lsb4.c
+++ b/src/writers/lsb4.c
@@ -1,8 +1,8 @@
 #include <writers.h>
 
-size_t embed_data_lsb1(FILE *output, const uint8_t *input, size_t size)
+size_t embed_data_lsb4(FILE *output, const uint8_t *input, size_t size)
 {
-    size *= 8;
+    size *= 4;
 
     uint8_t *data = malloc(size);
     if (data == NULL)
@@ -30,27 +30,21 @@ size_t embed_data_lsb1(FILE *output, const uint8_t *input, size_t size)
     size_t curr_byte = 0;
     while (curr_byte < size)
     {
-        uint8_t byte = input[curr_byte / 8];
+        uint8_t byte = input[curr_byte / 2];
 
         printf("Embedding byte: %02X\n", byte);
-        for (int i = 7; i >= 0; i--)
+        for (int i = 1; i >= 0; i--)
         {
-            uint8_t bit = (byte >> i) & 1;
+            uint8_t bit = (byte >> (i * 4)) & 0x0F;
             printf("Embedding bit: %d\n", bit);
 
-            data[curr_byte] = (data[curr_byte] & 0xFE) | bit;
+            data[curr_byte] = (data[curr_byte] & 0xF0) | bit;
             curr_byte++;
         }
     }
 
     size_t written = fwrite(data, sizeof(uint8_t), size, output);
     free(data);
-
-    if (written != size)
-    {
-        perror("Error writing to output file");
-        return 0;
-    }
 
     return written;
 }

--- a/src/writers/lsb4.c
+++ b/src/writers/lsb4.c
@@ -3,7 +3,7 @@
 
 size_t embed_data_lsb4(FILE *output, const uint8_t *input, size_t size)
 {
-    size *= 4;
+    size *= 2;
 
     uint8_t *data = malloc(size);
     if (data == NULL)

--- a/src/writers/lsb4.c
+++ b/src/writers/lsb4.c
@@ -32,11 +32,11 @@ size_t embed_data_lsb4(FILE *output, const uint8_t *input, size_t size)
     {
         uint8_t byte = input[curr_byte / 2];
 
-        printf("Embedding byte: %02X\n", byte);
+        LOG("Embedding byte: %02X\n", byte);
         for (int i = 1; i >= 0; i--)
         {
             uint8_t bit = (byte >> (i * 4)) & 0x0F;
-            printf("Embedding bit: %d\n", bit);
+            LOG("Embedding bit: %d\n", bit);
 
             data[curr_byte] = (data[curr_byte] & 0xF0) | bit;
             curr_byte++;

--- a/src/writers/lsb4.c
+++ b/src/writers/lsb4.c
@@ -47,5 +47,11 @@ size_t embed_data_lsb4(FILE *output, const uint8_t *input, size_t size)
     size_t written = fwrite(data, sizeof(uint8_t), size, output);
     free(data);
 
+    if (written != size)
+    {
+        perror("Error writing to output file");
+        return 0;
+    }
+
     return written;
 }


### PR DESCRIPTION
This pull request adds support for a new steganography method (LSB4) to the project, allowing users to choose between LSB1 and LSB4 for embedding and extracting messages in BMP files. Core logic is refactored to make the steganography method configurable via the command line, and the codebase is updated to support the new method throughout the embedding and extraction pipeline. Several robustness improvements and bug fixes are also included.

**New steganography method support:**

* Added the LSB4 steganography method with corresponding embedding (`embed_data_lsb4`) and extraction (`retrieve_lsb4`) implementations, alongside the existing LSB1 method.
* Introduced the `StegoMethod` struct and refactored the main logic in `src/stego.c` to select the method via the new `-stego` command line argument, making the embedding and extraction logic generic for both LSB1 and LSB4.

**Command-line and script changes:**

* Updated usage instructions and argument parsing to require the `-stego` parameter, and modified `run.sh` to pass the steganography method to the binary. 

**Robustness and bug fixes:**

* Improved error handling for file operations and memory allocation throughout the codebase, including checks for `fdopen` failure and output file writing errors.
* Fixed incorrect usage of `feof` and `fgetc` in message and extension extraction logic, and corrected the reading of message length and extension bytes. 

**Build system and dependencies:**

* Added `Makefile.inc` support for better build configuration, and updated the `Dockerfile` to include the `openssl` package.

**Header and type changes:**

* Moved `Writer` and `Reader` type definitions to `stego.h` and updated headers to support the new method interface.