### PR TITLE
Contiguous memory allocation for get_message

### DIFF
--- a/src/include/readers.h
+++ b/src/include/readers.h
@@ -21,11 +21,17 @@ size_t get_output(FILE **file, const char *output, const char *input);
 
 /**
  * @brief Get the message data
- * 
+ *
+ * @note The caller is responsible for freeing the allocated memory. NOTHING but the memory pointer should be freed.
+ * @note Data pointers will reference the allocated memory block.
+ * @note Success or failure can be determined by checking memory being NULL or not.
+ *
  * @param input The input file
+ * @param memory Pointer to consecutive allocated memory
+ * @param length Pointer to store the length of the data
  * @return Data The message data
  */
-Data get_message(const char *input);
+Data get_message(const char *input, uint8_t **memory, uint32_t *length);
 
 /**
  * @brief Retrieve a steganographed message using LSB1 method

--- a/src/include/readers.h
+++ b/src/include/readers.h
@@ -31,7 +31,7 @@ size_t get_output(FILE **file, const char *output, const char *input);
  * @param length Pointer to store the length of the data
  * @return Data The message data
  */
-Data get_message(const char *input, uint8_t **memory, uint32_t *length);
+Data get_message(const char *input, uint8_t **memory, size_t *length);
 
 /**
  * @brief Retrieve a steganographed message using LSB1 method

--- a/src/include/stego.h
+++ b/src/include/stego.h
@@ -6,7 +6,7 @@
 
 typedef struct {
     uint32_t size;
-    // little endian pointer to data size, preserved for legacy reasons
+    // big endian (network byte order) pointer to data size, preserved for legacy reasons
     uint32_t *sizep;
     char *data;
     char *ext;

--- a/src/include/stego.h
+++ b/src/include/stego.h
@@ -6,6 +6,7 @@
 
 typedef struct {
     uint32_t size;
+    uint32_t *sizep;
     char *data;
     char *ext;
 } Data;

--- a/src/include/stego.h
+++ b/src/include/stego.h
@@ -6,7 +6,7 @@
 
 typedef struct {
     uint32_t size;
-    // big endian (network byte order) pointer to data size, preserved for legacy reasons
+    // Big endian (network byte order) pointer to data size, preserved for legacy reasons
     uint32_t *sizep;
     char *data;
     char *ext;

--- a/src/include/stego.h
+++ b/src/include/stego.h
@@ -6,6 +6,7 @@
 
 typedef struct {
     uint32_t size;
+    // little endian pointer to data size, preserved for legacy reasons
     uint32_t *sizep;
     char *data;
     char *ext;

--- a/src/readers/input_file.c
+++ b/src/readers/input_file.c
@@ -7,7 +7,7 @@
 #include <stego.h>
 #include <logs.h>
 
-Data get_message(const char *input, uint8_t **memory, uint32_t *length)
+Data get_message(const char *input, uint8_t **memory, size_t *length)
 {
     FILE *file = fopen(input, "rb");
     if (file == NULL)

--- a/src/readers/input_file.c
+++ b/src/readers/input_file.c
@@ -43,10 +43,7 @@ Data get_message(const char *input, uint8_t **memory, uint32_t *length)
     if (*memory == NULL)
     {
         perror("Memory allocation failed");
-
-        *memory = NULL;
         fclose(file);
-
         return (Data){};
     }
 

--- a/src/readers/input_file.c
+++ b/src/readers/input_file.c
@@ -1,3 +1,4 @@
+#include <arpa/inet.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>
@@ -6,17 +7,13 @@
 #include <stego.h>
 #include <logs.h>
 
-Data get_message(const char *input)
+Data get_message(const char *input, uint8_t **memory, uint32_t *length)
 {
-    Data input_data = {
-        .size = 0,
-        .data = NULL,
-        .ext = NULL};
-
     FILE *file = fopen(input, "rb");
     if (file == NULL)
     {
         perror("Error opening input file");
+        *memory = NULL;
         return (Data){};
     }
 
@@ -27,29 +24,12 @@ Data get_message(const char *input)
     if (file_size < 0)
     {
         perror("Error determining file size");
+
+        *memory = NULL;
         fclose(file);
+
         return (Data){};
     }
-
-    input_data.data = malloc(file_size);
-    if (input_data.data == NULL)
-    {
-        perror("Memory allocation failed");
-        fclose(file);
-        return (Data){};
-    }
-
-    size_t read_size = fread(input_data.data, 1, file_size, file);
-    if (read_size != file_size)
-    {
-        perror("Error reading file");
-        free(input_data.data);
-        fclose(file);
-        return (Data){};
-    }
-
-    fclose(file);
-    input_data.size = (uint32_t)file_size;
 
     // Extract file extension including the dot
     const char *dot = strrchr(input, '.');
@@ -58,15 +38,43 @@ Data get_message(const char *input)
         dot = ""; // No extension found
     }
 
-    input_data.ext = strdup(dot);
-    if (input_data.ext == NULL)
+    *length = sizeof(uint32_t) + file_size + strlen(dot) + 1;
+    *memory = malloc(*length); // 4 bytes for size, file data, extension, null terminator
+    if (*memory == NULL)
     {
-        perror("Memory allocation for extension failed");
-        free(input_data.data);
-        input_data.data = NULL;
-        input_data.size = 0;
+        perror("Memory allocation failed");
+
+        *memory = NULL;
+        fclose(file);
+
         return (Data){};
     }
+
+    Data input_data = {
+        .size = file_size,
+        .sizep = (uint32_t *)(*memory),
+        .data = (char *)(*memory + sizeof(uint32_t)),
+        .ext = (char *)(*memory + sizeof(uint32_t) + file_size),
+    };
+
+    uint32_t endian_size = htonl(input_data.size);
+    memcpy(input_data.sizep, &endian_size, sizeof(uint32_t));
+
+    size_t read_size = fread(input_data.data, 1, file_size, file);
+    if (read_size != file_size)
+    {
+        perror("Error reading file");
+
+        free(*memory);
+        *memory = NULL;
+        fclose(file);
+
+        return (Data){};
+    }
+
+    fclose(file);
+
+    memcpy(input_data.ext, dot, strlen(dot) + 1); // Copy extension with null terminator
 
     LOG("Input file size: %u bytes\n", input_data.size);
     LOG("Input file extension: %s\n", input_data.ext);

--- a/src/readers/input_file.c
+++ b/src/readers/input_file.c
@@ -77,8 +77,8 @@ Data get_message(const char *input, uint8_t **memory, uint32_t *length)
     memcpy(input_data.ext, dot, strlen(dot) + 1); // Copy extension with null terminator
 
     LOG("Input file size: %u bytes\n", input_data.size);
-    LOG("Input file extension: %s\n", input_data.ext);
     LOG("Input file data: %.*s\n", input_data.size, input_data.data);
+    LOG("Input file extension: %s\n", input_data.ext);
 
     return input_data;
 }

--- a/src/readers/input_file.c
+++ b/src/readers/input_file.c
@@ -54,8 +54,7 @@ Data get_message(const char *input, uint8_t **memory, uint32_t *length)
         .ext = (char *)(*memory + sizeof(uint32_t) + file_size),
     };
 
-    uint32_t endian_size = htonl(input_data.size);
-    memcpy(input_data.sizep, &endian_size, sizeof(uint32_t));
+    *input_data.sizep = htonl(input_data.size);
 
     size_t read_size = fread(input_data.data, 1, file_size, file);
     if (read_size != file_size)

--- a/src/stego.c
+++ b/src/stego.c
@@ -31,34 +31,10 @@ int main(int argc, char *argv[])
             return EXIT_FAILURE;
         }
 
-        Data input_data = get_message(args.input_path);
-        if (input_data.data == NULL)
-        {
-            fclose(porter);
-            return EXIT_FAILURE;
-        }
-        if (input_data.ext == NULL)
-        {
-            perror("File extension couldn't be determined");
-            free(input_data.data);
-            fclose(porter);
-            return EXIT_FAILURE;
-        }
-        if (input_data.size == 0)
-        {
-            perror("Input file cannot be empty.");
-            free(input_data.data);
-            free(input_data.ext);
-            fclose(porter);
-            return EXIT_FAILURE;
-        }
-
         const BITMAPFILEHEADER header = get_bmp_file_header(porter);
         if (header.signature != 0x4D42)
         {
             fprintf(stderr, "Porter file is not a valid BMP file.\n");
-            free(input_data.data);
-            free(input_data.ext);
             fclose(porter);
             return EXIT_FAILURE;
         }
@@ -66,43 +42,30 @@ int main(int argc, char *argv[])
         uint32_t header_size = header.offset;
         fseek(porter, header_size, SEEK_SET); // Skip BMP header
 
-        // turn the size into 4 bytes
-        uint8_t size_bytes[4];
-        size_bytes[0] = (input_data.size >> 24) & 0xFF;
-        size_bytes[1] = (input_data.size >> 16) & 0xFF;
-        size_bytes[2] = (input_data.size >> 8) & 0xFF;
-        size_bytes[3] = input_data.size & 0xFF;
+        uint8_t *memory;
+        uint32_t length;
+        Data input_data = get_message(args.input_path, &memory, &length);
+        if (!memory)
+        {
+            perror("Failed to get input message");
+            fclose(porter);
+            return EXIT_FAILURE;
+        }
 
-        if (args.stego.embed(porter, size_bytes, 4) == 0)
+        if (!args.stego.embed(porter, memory, length))
         {
-            fprintf(stderr, "Failed to embed size data.\n");
-            free(input_data.data);
-            free(input_data.ext);
+            fprintf(stderr, "Failed to embed data.\n");
+
+            free(memory);
             fclose(porter);
-            return EXIT_FAILURE;
-        }
-        if (args.stego.embed(porter, (uint8_t *)input_data.data, input_data.size) == 0)
-        {
-            fprintf(stderr, "Failed to embed input data.\n");
-            free(input_data.data);
-            free(input_data.ext);
-            fclose(porter);
-            return EXIT_FAILURE;
-        }
-        if (args.stego.embed(porter, (uint8_t *)input_data.ext, strlen(input_data.ext) + 1) == 0)
-        {
-            fprintf(stderr, "Failed to embed file extension data.\n");
-            free(input_data.data);
-            free(input_data.ext);
-            fclose(porter);
+
             return EXIT_FAILURE;
         }
 
         printf("Data embedded successfully into '%s'.\n", args.output_path);
 
         // free memory and close files
-        free(input_data.data);
-        free(input_data.ext);
+        free(memory);
         fclose(porter);
     }
     else

--- a/src/stego.c
+++ b/src/stego.c
@@ -44,7 +44,8 @@ int main(int argc, char *argv[])
 
         uint8_t *memory;
         size_t length;
-        Data input_data = get_message(args.input_path, &memory, &length);
+        get_message(args.input_path, &memory, &length);
+
         if (!memory)
         {
             perror("Failed to get input message");

--- a/src/stego.c
+++ b/src/stego.c
@@ -43,7 +43,7 @@ int main(int argc, char *argv[])
         fseek(porter, header_size, SEEK_SET); // Skip BMP header
 
         uint8_t *memory;
-        uint32_t length;
+        size_t length;
         Data input_data = get_message(args.input_path, &memory, &length);
         if (!memory)
         {


### PR DESCRIPTION
Use a contiguous memory to save the object data, useful for embeding and encrypting.

This branch aims at simplifying the merge of #14 and the WIP encription branch, which both require a single contiguous memory for embeding and encrypting the bytes. This branch is conflict free with lsbi, but not encripting, which already has a similar implementation of the code.

Good luck to whoever has to deal with that merge :]